### PR TITLE
#4 [WIP] 진도공유: 둥근 탭바, 섹션 헤더 시도

### DIFF
--- a/CCC-1st-Toss-Eunice.xcodeproj/project.pbxproj
+++ b/CCC-1st-Toss-Eunice.xcodeproj/project.pbxproj
@@ -11,8 +11,8 @@
 		C5158204286C2A4E0011A308 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5158203286C2A4E0011A308 /* ContentView.swift */; };
 		C5158206286C2A4F0011A308 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C5158205286C2A4F0011A308 /* Assets.xcassets */; };
 		C5158209286C2A4F0011A308 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C5158208286C2A4F0011A308 /* Preview Assets.xcassets */; };
-		C5158210286C2D580011A308 /* TestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C515820F286C2D580011A308 /* TestView.swift */; };
 		C5158215286C30E10011A308 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = C5158214286C30E10011A308 /* .swiftlint.yml */; };
+		C5158217286CDE470011A308 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5158216286CDE470011A308 /* HomeView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,8 +21,8 @@
 		C5158203286C2A4E0011A308 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C5158205286C2A4F0011A308 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C5158208286C2A4F0011A308 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
-		C515820F286C2D580011A308 /* TestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestView.swift; sourceTree = "<group>"; };
 		C5158214286C30E10011A308 /* .swiftlint.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		C5158216286CDE470011A308 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,8 +59,8 @@
 				C5158203286C2A4E0011A308 /* ContentView.swift */,
 				C5158205286C2A4F0011A308 /* Assets.xcassets */,
 				C5158207286C2A4F0011A308 /* Preview Content */,
-				C515820F286C2D580011A308 /* TestView.swift */,
 				C5158214286C30E10011A308 /* .swiftlint.yml */,
+				C5158216286CDE470011A308 /* HomeView.swift */,
 			);
 			path = "CCC-1st-Toss-Eunice";
 			sourceTree = "<group>";
@@ -166,7 +166,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C5158210286C2D580011A308 /* TestView.swift in Sources */,
+				C5158217286CDE470011A308 /* HomeView.swift in Sources */,
 				C5158204286C2A4E0011A308 /* ContentView.swift in Sources */,
 				C5158202286C2A4E0011A308 /* CCC_1st_Toss_EuniceApp.swift in Sources */,
 			);

--- a/CCC-1st-Toss-Eunice/ContentView.swift
+++ b/CCC-1st-Toss-Eunice/ContentView.swift
@@ -8,9 +8,58 @@
 import SwiftUI
 
 struct ContentView: View {
+    
+//    init(){
+//        UITabBar
+//            .appearance()
+//            .backgroundColor = UIColor.clear
+//    }
+    
     var body: some View {
-        Text("Hello, world!")
-            .padding()
+//        ZStack(alignment: .bottom) {
+            TabView {
+                // 탭바 끝에 둥근 마무리 필요 - 탭 바 좀 내리고? 뒤에 배경
+                // 아래 pane이 pinned view인 것 필요
+                // HomeView()
+                // 지금 위치고정 안 됨
+                customeTabBarBackground(content: HomeView())
+                    //.ignoresSafeArea()
+                    .tabItem {
+                        Image(systemName: "house.fill")
+                        Text("홈")
+                    }
+                customeTabBarBackground(content: Text("혜택"))
+                    .tabItem {
+                        Image(systemName: "pentagon.fill")
+                        Text("혜택")
+                    }
+                customeTabBarBackground(content: Text("송금"))
+                    .tabItem {
+                        Image(systemName: "paperplane.fill")
+                        Text("송금")
+                    }
+
+                customeTabBarBackground(content: Text("주식"))
+                    .tabItem {
+                        Image(systemName: "banknote.fill")
+                        Text("주식")
+                    }
+
+                Text("전체")
+                    .tabItem {
+                        Image(systemName: "slider.horizontal.3")
+                        Text("전체")
+                    }
+            }
+    }
+}
+func customeTabBarBackground<Content: View>(content: Content) -> some View {
+    ZStack(alignment: .bottom) {
+        content
+        RoundedRectangle(cornerRadius: 24)
+            .fill(.pink)
+            .ignoresSafeArea()
+            .frame(width: UIScreen.main.bounds.width, height: 0)
     }
 }
 

--- a/CCC-1st-Toss-Eunice/HomeView.swift
+++ b/CCC-1st-Toss-Eunice/HomeView.swift
@@ -1,0 +1,50 @@
+//
+//  HomeView.swift
+//  CCC-1st-Toss-Eunice
+//
+//  Created by Hyorim Nam on 2022/06/30.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+//        ZStack(alignment: .bottom) {
+//            TabBarBackGroundView()
+            ScrollView {
+                LazyVStack(pinnedViews: .sectionHeaders) {
+                    ForEach(0...4, id: \.self){ idx in
+                        Text("\(idx)")
+                            .frame(width: 200, height: 200)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .fill(.blue)
+                            )
+                    }
+                    Section(header: Text("headerTest")) {
+                        ForEach(0...4, id: \.self){ idx in
+                            Text("\(idx)")
+                                .frame(width: 200, height: 200)
+                                .padding()
+                                .background(
+                                    RoundedRectangle(cornerRadius: 16).fill(.green)
+                                )
+                        }
+                    }
+                }
+            }
+            .background(
+                Color(.orange)
+                .ignoresSafeArea()
+                )
+
+        }
+//    }
+}
+
+struct HomeView_Previews: PreviewProvider {
+    static var previews: some View {
+        HomeView()
+    }
+}


### PR DESCRIPTION
## 관련 이슈
#4 최소 UI

## 작업 내용
시도함
- [ ] 둥근 탭바
- [ ] 섹션 헤더 (스크롤했을 때 위치가 고정되어 보이는 pinned view)

## 고민한 내용
- SwiftUI에서 탭바 모양을 커스텀하는 방법
  - 배경을 투명하게 하고 ZStack으로 배경색 넣고 싶었음
  - 컨텐츠뷰의 탭뷰 위에 탭 내용 뷰가 쌓이기 때문에 탭바 뒤에 배경을 넣을 수는 없음

## 리뷰 포인트


## 다음으로 진행할 작업
- 탭바 고정, 스크롤뷰 상태에 따라 잘 나오는지 확인
- 섹션 헤더


## Reference
